### PR TITLE
Updated to the latest version 0.31.3 and fixed `--returndata` argument case.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Use the uselagoon/lagoon-cli as a base image
 # FROM uselagoon/lagoon-cli as base
-FROM ghcr.io/uselagoon/lagoon-cli:v0.21.0 as base
+FROM ghcr.io/uselagoon/lagoon-cli:v0.31.3 as base
 
 
 RUN apk update && apk upgrade && apk add python3 py3-pip

--- a/action.py
+++ b/action.py
@@ -112,8 +112,8 @@ def deploy_pull_request(project_name, pr_title, pr_number, baseBranchName, baseB
     # Lagoon CLI command to deploy the latest version with --output-json flag
     lagoon_command = (
         f"lagoon -l {LAGOON_NAME} --skip-update-check --returndata --force --output-json -i ~/.ssh/id_rsa deploy pullrequest "
-        f"-p '{project_name}' --baseBranchName '{baseBranchName}' --baseBranchRef '{baseBranchRef}' "
-        f"--headBranchName '{headBranchName}' --headBranchRef {headBranchRef} "
+        f"-p '{project_name}' --base-branch-name '{baseBranchName}' --base-branch-ref '{baseBranchRef}' "
+        f"--head-branch-name '{headBranchName}' --head-branch-ref {headBranchRef} "
         f"--title '{pr_title}' --number {pr_number} {buildVarArgumentString}"
     )
 

--- a/action.py
+++ b/action.py
@@ -83,7 +83,7 @@ def deploy_environment(project_name, environment_name, buildVars, wait_till_depl
     buildVarArgumentString = ' '.join(stringMap)
     # Lagoon CLI command to deploy the latest version with --output-json flag
     lagoon_command = (
-        f"lagoon -l {LAGOON_NAME} --skip-update-check --returnData --force --output-json -i ~/.ssh/id_rsa deploy branch "
+        f"lagoon -l {LAGOON_NAME} --skip-update-check --returndata --force --output-json -i ~/.ssh/id_rsa deploy branch "
         f"-p {project_name} -b {environment_name} {buildVarArgumentString}"
     )
 
@@ -111,7 +111,7 @@ def deploy_pull_request(project_name, pr_title, pr_number, baseBranchName, baseB
 
     # Lagoon CLI command to deploy the latest version with --output-json flag
     lagoon_command = (
-        f"lagoon -l {LAGOON_NAME} --skip-update-check --returnData --force --output-json -i ~/.ssh/id_rsa deploy pullrequest "
+        f"lagoon -l {LAGOON_NAME} --skip-update-check --returndata --force --output-json -i ~/.ssh/id_rsa deploy pullrequest "
         f"-p '{project_name}' --baseBranchName '{baseBranchName}' --baseBranchRef '{baseBranchRef}' "
         f"--headBranchName '{headBranchName}' --headBranchRef {headBranchRef} "
         f"--title '{pr_title}' --number {pr_number} {buildVarArgumentString}"


### PR DESCRIPTION
```
Deploying branch: ....
Error executing Lagoon CLI command: Command 'lagoon -l lagoon --returnData --force --output-json -i ~/.ssh/id_rsa deploy branch -p REDACTED -b main' returned non-zero exit status 1.
Command output: 
Command error: Error: unknown flag: --returnData
```

After using an action with changes in this PR, the deployment worked.